### PR TITLE
dart-sdk: drop unzip inheritance

### DIFF
--- a/sources/meta-flutter/recipes-devtools/dart/dart-sdk_3.7.0.bb
+++ b/sources/meta-flutter/recipes-devtools/dart/dart-sdk_3.7.0.bb
@@ -4,8 +4,6 @@ SRC_URI = "https://storage.googleapis.com/dart-archive/channels/stable/release/3
 SRC_URI[sha256sum] = "0000000000000000000000000000000000000000000000000000000000000000"
 S = "${WORKDIR}/dart-sdk"
 
-inherit unzip
-
 RDEPENDS:${PN} = ""
 
 PACKAGE_ARCH = "${MACHINE_ARCH}"


### PR DESCRIPTION
## Summary
- fix dart-sdk recipe by removing obsolete `unzip` class

## Testing
- `bitbake-layers show-recipes dart-sdk` *(fails: Please make sure locale 'en_US.UTF-8' is available on your system)*

------
https://chatgpt.com/codex/tasks/task_e_68b2159647588327b1db705e3a75a7e9