### PR TITLE
Add audio and AI packages to imx-image-full

### DIFF
--- a/sources/meta-imx/meta-imx-sdk/dynamic-layers/qt6-layer/recipes-fsl/images/imx-image-full.bb
+++ b/sources/meta-imx/meta-imx-sdk/dynamic-layers/qt6-layer/recipes-fsl/images/imx-image-full.bb
@@ -16,6 +16,24 @@ IMAGE_INSTALL += " \
     ${IMAGE_INSTALL_OPENCV} \
     ${IMAGE_INSTALL_PARSEC} \
     ${IMAGE_INSTALL_PKCS11TOOL} \
+    pipewire \
+    pipewire-pulse \
+    wireplumber \
+    gstreamer1.0 \
+    gstreamer1.0-plugins-base \
+    gstreamer1.0-plugins-good \
+    gstreamer1.0-plugins-bad \
+    gstreamer1.0-plugins-ugly \
+    ladspa-sdk \
+    lv2 \
+    gstreamer1.0-plugins-ladspa \
+    jack \
+    ardour \
+    tensorflow-lite \
+    armnn \
+    onnxruntime \
+    fftw \
+    libsamplerate0 \
 "
 
 IMAGE_INSTALL_OPENCV              = ""

--- a/sources/meta-nxp-demo-experience/recipes-gopoint/imx-image-full/imx-image-full.bbappend
+++ b/sources/meta-nxp-demo-experience/recipes-gopoint/imx-image-full/imx-image-full.bbappend
@@ -1,3 +1,11 @@
+IMAGE_INSTALL:append = "\
+    pipewire pipewire-pulse wireplumber \
+    gstreamer1.0 gstreamer1.0-plugins-base gstreamer1.0-plugins-good \
+    gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly \
+    ladspa-sdk lv2 gstreamer1.0-plugins-ladspa \
+    ardour tensorflow-lite armnn onnxruntime fftw libsamplerate \
+"
+
 ROOTFS_POSTPROCESS_COMMAND:append:mx93-nxp-bsp = "install_demo_93; "
 ROOTFS_POSTPROCESS_COMMAND:append:mx8-nxp-bsp = "install_demo; "
 ROOTFS_POSTPROCESS_COMMAND:append:mx95-nxp-bsp = "install_demo; "


### PR DESCRIPTION
## Summary
- include PipeWire, GStreamer, LADSPA/LV2, Ardour, and AI libraries in `imx-image-full`

## Testing
- `source setup-environment build && bitbake -n imx-image-full` *(fails: do not use the BSP as root)*

------
https://chatgpt.com/codex/tasks/task_e_68b21bd00e14832799d3aced0872c54f