### PR TITLE
Handle gstreamer ugly plugin license in imx image

### DIFF
--- a/sources/meta-imx/meta-imx-sdk/dynamic-layers/qt6-layer/recipes-fsl/images/imx-image-full.bb
+++ b/sources/meta-imx/meta-imx-sdk/dynamic-layers/qt6-layer/recipes-fsl/images/imx-image-full.bb
@@ -23,7 +23,7 @@ IMAGE_INSTALL += " \
     gstreamer1.0-plugins-base \
     gstreamer1.0-plugins-good \
     gstreamer1.0-plugins-bad \
-    gstreamer1.0-plugins-ugly \
+    ${@bb.utils.contains('LICENSE_FLAGS_ACCEPTED', 'commercial', 'gstreamer1.0-plugins-ugly', '', d)} \
     ladspa-sdk \
     lv2 \
     gstreamer1.0-plugins-ladspa \

--- a/sources/meta-nxp-demo-experience/recipes-gopoint/imx-image-full/imx-image-full.bbappend
+++ b/sources/meta-nxp-demo-experience/recipes-gopoint/imx-image-full/imx-image-full.bbappend
@@ -1,7 +1,7 @@
 IMAGE_INSTALL:append = "\
     pipewire pipewire-pulse wireplumber \
     gstreamer1.0 gstreamer1.0-plugins-base gstreamer1.0-plugins-good \
-    gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly \
+    gstreamer1.0-plugins-bad ${@bb.utils.contains('LICENSE_FLAGS_ACCEPTED', 'commercial', 'gstreamer1.0-plugins-ugly', '', d)} \
     ladspa-sdk lv2 gstreamer1.0-plugins-ladspa \
     ardour tensorflow-lite armnn onnxruntime fftw libsamplerate \
 "


### PR DESCRIPTION
## Summary
- include gstreamer1.0-plugins-ugly only when `commercial` license is accepted

## Testing
- `MACHINE=imx8mmpevk DISTRO=fsl-imx-xwayland source setup-environment build` *(fails: do not use the BSP as root)*

------
https://chatgpt.com/codex/tasks/task_e_68b22d8d44608327b1f04d12b5d786dd