### PR TITLE
Remove ladspa-sdk from imx-image-full dependencies

### DIFF
--- a/sources/meta-imx/meta-imx-sdk/dynamic-layers/qt6-layer/recipes-fsl/images/imx-image-full.bb
+++ b/sources/meta-imx/meta-imx-sdk/dynamic-layers/qt6-layer/recipes-fsl/images/imx-image-full.bb
@@ -24,7 +24,6 @@ IMAGE_INSTALL += " \
     gstreamer1.0-plugins-good \
     gstreamer1.0-plugins-bad \
     ${@bb.utils.contains('LICENSE_FLAGS_ACCEPTED', 'commercial', 'gstreamer1.0-plugins-ugly', '', d)} \
-    ladspa-sdk \
     lv2 \
     gstreamer1.0-plugins-ladspa \
     jack \

--- a/sources/meta-nxp-demo-experience/recipes-gopoint/imx-image-full/imx-image-full.bbappend
+++ b/sources/meta-nxp-demo-experience/recipes-gopoint/imx-image-full/imx-image-full.bbappend
@@ -2,7 +2,7 @@ IMAGE_INSTALL:append = "\
     pipewire pipewire-pulse wireplumber \
     gstreamer1.0 gstreamer1.0-plugins-base gstreamer1.0-plugins-good \
     gstreamer1.0-plugins-bad ${@bb.utils.contains('LICENSE_FLAGS_ACCEPTED', 'commercial', 'gstreamer1.0-plugins-ugly', '', d)} \
-    ladspa-sdk lv2 gstreamer1.0-plugins-ladspa \
+    lv2 gstreamer1.0-plugins-ladspa \
     ardour tensorflow-lite armnn onnxruntime fftw libsamplerate \
 "
 


### PR DESCRIPTION
## Summary
- drop ladspa-sdk from imx-image-full image recipes

## Testing
- `source setup-environment build` *(fails: do not use the BSP as root)*

------
https://chatgpt.com/codex/tasks/task_e_68b22eb0fcd8832796fe39008f7cd5a5