### PR TITLE
Remove unbuildable ladspa plugin dependency

### DIFF
--- a/sources/meta-imx/meta-imx-sdk/dynamic-layers/qt6-layer/recipes-fsl/images/imx-image-full.bb
+++ b/sources/meta-imx/meta-imx-sdk/dynamic-layers/qt6-layer/recipes-fsl/images/imx-image-full.bb
@@ -24,7 +24,6 @@ IMAGE_INSTALL += " \
     gstreamer1.0-plugins-good \
     gstreamer1.0-plugins-bad \
     ${@bb.utils.contains('LICENSE_FLAGS_ACCEPTED', 'commercial', 'gstreamer1.0-plugins-ugly', '', d)} \
-    gstreamer1.0-plugins-ladspa \
     jack \
     ardour \
     tensorflow-lite \

--- a/sources/meta-nxp-demo-experience/recipes-gopoint/imx-image-full/imx-image-full.bbappend
+++ b/sources/meta-nxp-demo-experience/recipes-gopoint/imx-image-full/imx-image-full.bbappend
@@ -2,7 +2,6 @@ IMAGE_INSTALL:append = "\
     pipewire pipewire-pulse wireplumber \
     gstreamer1.0 gstreamer1.0-plugins-base gstreamer1.0-plugins-good \
     gstreamer1.0-plugins-bad ${@bb.utils.contains('LICENSE_FLAGS_ACCEPTED', 'commercial', 'gstreamer1.0-plugins-ugly', '', d)} \
-    gstreamer1.0-plugins-ladspa \
     ardour tensorflow-lite armnn onnxruntime fftw libsamplerate \
 "
 


### PR DESCRIPTION
## Summary
- drop `gstreamer1.0-plugins-ladspa` from `imx-image-full` so image no longer depends on a plugin that is not built

## Testing
- `bitbake -p imx-image-full` *(fails: Do not use Bitbake as root)*

------
https://chatgpt.com/codex/tasks/task_e_68b231fba6388327b9b6081c1aaa61d5