### PR TITLE
Remove broken ardour dependency from imx-image-full

### DIFF
--- a/sources/meta-imx/meta-imx-sdk/dynamic-layers/qt6-layer/recipes-fsl/images/imx-image-full.bb
+++ b/sources/meta-imx/meta-imx-sdk/dynamic-layers/qt6-layer/recipes-fsl/images/imx-image-full.bb
@@ -25,7 +25,6 @@ IMAGE_INSTALL += " \
     gstreamer1.0-plugins-bad \
     ${@bb.utils.contains('LICENSE_FLAGS_ACCEPTED', 'commercial', 'gstreamer1.0-plugins-ugly', '', d)} \
     jack \
-    ardour \
     tensorflow-lite \
     armnn \
     onnxruntime \

--- a/sources/meta-nxp-demo-experience/recipes-gopoint/imx-image-full/imx-image-full.bbappend
+++ b/sources/meta-nxp-demo-experience/recipes-gopoint/imx-image-full/imx-image-full.bbappend
@@ -2,7 +2,7 @@ IMAGE_INSTALL:append = "\
     pipewire pipewire-pulse wireplumber \
     gstreamer1.0 gstreamer1.0-plugins-base gstreamer1.0-plugins-good \
     gstreamer1.0-plugins-bad ${@bb.utils.contains('LICENSE_FLAGS_ACCEPTED', 'commercial', 'gstreamer1.0-plugins-ugly', '', d)} \
-    ardour tensorflow-lite armnn onnxruntime fftw libsamplerate \
+    tensorflow-lite armnn onnxruntime fftw libsamplerate \
 "
 
 ROOTFS_POSTPROCESS_COMMAND:append:mx93-nxp-bsp = "install_demo_93; "


### PR DESCRIPTION
## Summary
- drop ardour from imx-image-full image since no recipe provides it

## Testing
- `MACHINE=imx8mp DISTRO=fslc-wayland source setup-environment build 2>&1 | head -n 20` *(fails: do not use the BSP as root)*

------
https://chatgpt.com/codex/tasks/task_e_68b233f3bde883278415dccafc2e70bd