### PR TITLE
Remove armnn dependency from imx-image-full image

### DIFF
--- a/sources/meta-imx/meta-imx-sdk/dynamic-layers/qt6-layer/recipes-fsl/images/imx-image-full.bb
+++ b/sources/meta-imx/meta-imx-sdk/dynamic-layers/qt6-layer/recipes-fsl/images/imx-image-full.bb
@@ -26,7 +26,6 @@ IMAGE_INSTALL += " \
     ${@bb.utils.contains('LICENSE_FLAGS_ACCEPTED', 'commercial', 'gstreamer1.0-plugins-ugly', '', d)} \
     jack \
     tensorflow-lite \
-    armnn \
     onnxruntime \
     fftw \
     libsamplerate0 \

--- a/sources/meta-nxp-demo-experience/recipes-gopoint/imx-image-full/imx-image-full.bbappend
+++ b/sources/meta-nxp-demo-experience/recipes-gopoint/imx-image-full/imx-image-full.bbappend
@@ -2,7 +2,7 @@ IMAGE_INSTALL:append = "\
     pipewire pipewire-pulse wireplumber \
     gstreamer1.0 gstreamer1.0-plugins-base gstreamer1.0-plugins-good \
     gstreamer1.0-plugins-bad ${@bb.utils.contains('LICENSE_FLAGS_ACCEPTED', 'commercial', 'gstreamer1.0-plugins-ugly', '', d)} \
-    tensorflow-lite armnn onnxruntime fftw libsamplerate \
+    tensorflow-lite onnxruntime fftw libsamplerate \
 "
 
 ROOTFS_POSTPROCESS_COMMAND:append:mx93-nxp-bsp = "install_demo_93; "


### PR DESCRIPTION
## Summary
- remove armnn from imx-image-full image recipes to avoid unbuildable dependency

## Testing
- `LC_ALL=en_US.UTF-8 bitbake-layers show-recipes armnn` *(fails: Unable to start bitbake server; locale en_US.UTF-8 not available)*

------
https://chatgpt.com/codex/tasks/task_e_68b2aae666bc8327a883704d2bf269c6