### PR TITLE
linux-imx: add Upstream-Status

### DIFF
--- a/sources/meta-imx/meta-imx-bsp/recipes-kernel/linux/linux-imx/0001-uac2-use-out-clock-for-input.patch
+++ b/sources/meta-imx/meta-imx-bsp/recipes-kernel/linux/linux-imx/0001-uac2-use-out-clock-for-input.patch
@@ -3,6 +3,8 @@ From: Libre Agent <libre@agent>
 Date: Thu, 1 Jan 1970 00:00:00 +0000
 Subject: [PATCH] usb: gadget: uac2: share output clock for input
 
+Upstream-Status: Backport [from Linux v6.6.36]
+
 Port patch from kernel 6.6.36 to use a single clock source for both
 playback and capture in the USB Audio Class 2 gadget driver. The input
 clock descriptor is removed and the output clock is reused for input


### PR DESCRIPTION
## Summary
- mark USB Audio Class 2 patch as a backport from Linux v6.6.36

## Testing
- `bitbake -n -c patch linux-imx` *(fails: Do not use Bitbake as root)*

------
https://chatgpt.com/codex/tasks/task_e_68b2c579661083278e5c151d5cb8472d