### PR TITLE
Limit Yocto build to eight threads

### DIFF
--- a/sources/meta-imx/tools/imx-setup-release.sh
+++ b/sources/meta-imx/tools/imx-setup-release.sh
@@ -147,8 +147,9 @@ echo "EXTRA_IMAGE_FEATURES += \"package-management\"" >> conf/local.conf
 ##echo "IMAGE_INSTALL:append = \"android-tools android-tools-conf\"" >> conf/local.conf
 
 
-### John_gao 
-echo "BB_NUMBER_THREADS = \"16\"" >> conf/local.conf
+### John_gao
+echo "BB_NUMBER_THREADS = \"8\"" >> conf/local.conf
+echo "PARALLEL_MAKE = \"-j 8\"" >> conf/local.conf
 echo "IMAGE_FSTYPES = \"wic tar.bz2\"" >> conf/local.conf
 
 if [ ! -e $BUILD_DIR/conf/bblayers.conf.org ]; then


### PR DESCRIPTION
## Summary
- limit default BitBake tasks to eight threads
- constrain internal make jobs to eight threads

## Testing
- `bash -n sources/meta-imx/tools/imx-setup-release.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b334ec974483279548a84edcac141e