### PR TITLE
Reduce parallel build threads to 8

### DIFF
--- a/sources/meta-arm/kas/corstone1000-base.yml
+++ b/sources/meta-arm/kas/corstone1000-base.yml
@@ -43,8 +43,8 @@ local_conf_header:
 
   setup: |
     PACKAGE_CLASSES = "package_ipk"
-    BB_NUMBER_THREADS ?= "16"
-    PARALLEL_MAKE ?= "-j16"
+    BB_NUMBER_THREADS ?= "8"
+    PARALLEL_MAKE ?= "-j8"
     PACKAGECONFIG:append:pn-perf = " coresight"
 
 machine: unset


### PR DESCRIPTION
## Summary
- Decrease Yocto default build concurrency from 16 to 8 threads

## Testing
- `yamllint sources/meta-arm/kas/corstone1000-base.yml && echo OK`


------
https://chatgpt.com/codex/tasks/task_e_68b3582f7c0c8327a0dd39c19edde270