### PR TITLE
Fix imx-image-full package names for jack and fftw

### DIFF
--- a/sources/meta-imx/meta-imx-sdk/dynamic-layers/qt6-layer/recipes-fsl/images/imx-image-full.bb
+++ b/sources/meta-imx/meta-imx-sdk/dynamic-layers/qt6-layer/recipes-fsl/images/imx-image-full.bb
@@ -24,10 +24,11 @@ IMAGE_INSTALL += " \
     gstreamer1.0-plugins-good \
     gstreamer1.0-plugins-bad \
     ${@bb.utils.contains('LICENSE_FLAGS_ACCEPTED', 'commercial', 'gstreamer1.0-plugins-ugly', '', d)} \
-    jack \
+    jack-server \
+    jack-utils \
     tensorflow-lite \
     onnxruntime \
-    fftw \
+    libfftw \
     libsamplerate0 \
 "
 

--- a/sources/meta-nxp-demo-experience/recipes-gopoint/imx-image-full/imx-image-full.bbappend
+++ b/sources/meta-nxp-demo-experience/recipes-gopoint/imx-image-full/imx-image-full.bbappend
@@ -2,7 +2,7 @@ IMAGE_INSTALL:append = "\
     pipewire pipewire-pulse wireplumber \
     gstreamer1.0 gstreamer1.0-plugins-base gstreamer1.0-plugins-good \
     gstreamer1.0-plugins-bad ${@bb.utils.contains('LICENSE_FLAGS_ACCEPTED', 'commercial', 'gstreamer1.0-plugins-ugly', '', d)} \
-    tensorflow-lite onnxruntime fftw libsamplerate0 \
+    tensorflow-lite onnxruntime libfftw libsamplerate0 \
 "
 
 ROOTFS_POSTPROCESS_COMMAND:append:mx93-nxp-bsp = "install_demo_93; "


### PR DESCRIPTION
## Summary
- Replace nonexistent `jack` and `fftw` packages with valid `jack-server`, `jack-utils`, and `libfftw`
- Ensure demo image recipe pulls correct audio and FFT libraries

## Testing
- `su - builder -c 'cd /workspace/yocto-nxp-debix; bash -lc "export LC_ALL=en_US.UTF-8; source sources/poky/oe-init-build-env ~/build >/tmp/init.log && bitbake -n imx-image-full"'` *(failed: missing host tools `chrpath cpio diffstat file lz4c pzstd unzstd zstd`)*

------
https://chatgpt.com/codex/tasks/task_e_68b43dd52bdc832785fc23024899d501