### PR TITLE
Fix missing jack-utils dependency

### DIFF
--- a/sources/meta-imx/meta-imx-sdk/dynamic-layers/qt6-layer/recipes-fsl/images/imx-image-full.bb
+++ b/sources/meta-imx/meta-imx-sdk/dynamic-layers/qt6-layer/recipes-fsl/images/imx-image-full.bb
@@ -25,7 +25,6 @@ IMAGE_INSTALL += " \
     gstreamer1.0-plugins-bad \
     ${@bb.utils.contains('LICENSE_FLAGS_ACCEPTED', 'commercial', 'gstreamer1.0-plugins-ugly', '', d)} \
     jack-server \
-    jack-utils \
     tensorflow-lite \
     onnxruntime \
     libfftw \


### PR DESCRIPTION
## Summary
- remove unavailable `jack-utils` package from `imx-image-full`

## Testing
- `source setup-environment builddir` *(fails: do not use the BSP as root)*
- `bitbake-layers show-recipes imx-image-full` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b445dd6254832792a882d1161e0cf8