### PR TITLE
Use jack package instead of jack-server

### DIFF
--- a/sources/meta-imx/meta-imx-sdk/dynamic-layers/qt6-layer/recipes-fsl/images/imx-image-full.bb
+++ b/sources/meta-imx/meta-imx-sdk/dynamic-layers/qt6-layer/recipes-fsl/images/imx-image-full.bb
@@ -24,7 +24,7 @@ IMAGE_INSTALL += " \
     gstreamer1.0-plugins-good \
     gstreamer1.0-plugins-bad \
     ${@bb.utils.contains('LICENSE_FLAGS_ACCEPTED', 'commercial', 'gstreamer1.0-plugins-ugly', '', d)} \
-    jack-server \
+    jack \
     tensorflow-lite \
     onnxruntime \
     libfftw \

--- a/sources/meta-openembedded/meta-oe/recipes-core/packagegroups/packagegroup-meta-oe.bb
+++ b/sources/meta-openembedded/meta-oe/recipes-core/packagegroups/packagegroup-meta-oe.bb
@@ -661,8 +661,7 @@ RDEPENDS:packagegroup-meta-oe-multimedia ="\
     id3lib \
     audiofile \
     a2jmidid \
-    jack-server \
-    jack-utils \
+    jack \
     libass \
     libcdio-paranoia \
     libcdio \


### PR DESCRIPTION
## Summary
- install jack package instead of jack-server in imx-image-full and multimedia package group
- drop jack-utils from multimedia package group since it's part of jack

## Testing
- `bitbake imx-image-full -n` *(fails: locale 'en_US.UTF-8' is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b44e8f4eac8327b1f5761973d9fb67