### PR TITLE
Replace jack meta package with subpackages in imx-image-full

### DIFF
--- a/sources/meta-imx/meta-imx-sdk/dynamic-layers/qt6-layer/recipes-fsl/images/imx-image-full.bb
+++ b/sources/meta-imx/meta-imx-sdk/dynamic-layers/qt6-layer/recipes-fsl/images/imx-image-full.bb
@@ -24,7 +24,9 @@ IMAGE_INSTALL += " \
     gstreamer1.0-plugins-good \
     gstreamer1.0-plugins-bad \
     ${@bb.utils.contains('LICENSE_FLAGS_ACCEPTED', 'commercial', 'gstreamer1.0-plugins-ugly', '', d)} \
-    jack \
+    jack-server \
+    jack-utils \
+    libjack \
     tensorflow-lite \
     onnxruntime \
     libfftw \


### PR DESCRIPTION
## Summary
- expand imx-image-full IMAGE_INSTALL with jack-server, jack-utils and libjack

## Testing
- `source setup-environment build` *(fails: do not use the BSP as root)*
- `bitbake imx-image-full` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b45b5b4e2c8327939c9b04f1067b0a