### PR TITLE
Drop jack packages from image

### DIFF
--- a/sources/meta-imx/meta-imx-sdk/dynamic-layers/qt6-layer/recipes-fsl/images/imx-image-full.bb
+++ b/sources/meta-imx/meta-imx-sdk/dynamic-layers/qt6-layer/recipes-fsl/images/imx-image-full.bb
@@ -24,7 +24,6 @@ IMAGE_INSTALL += " \
     gstreamer1.0-plugins-good \
     gstreamer1.0-plugins-bad \
     ${@bb.utils.contains('LICENSE_FLAGS_ACCEPTED', 'commercial', 'gstreamer1.0-plugins-ugly', '', d)} \
-    jack \
     tensorflow-lite \
     onnxruntime \
     libfftw \
@@ -38,6 +37,9 @@ IMAGE_INSTALL_OPENCV_PKGS = " \
     opencv-apps \
     opencv-samples \
     python3-opencv"
+
+# Disable JACK integration in PipeWire to drop jack runtime dependency
+PACKAGECONFIG:remove:pn-pipewire = "jack"
 
 IMAGE_INSTALL_PARSEC = " \
     packagegroup-security-tpm2 \


### PR DESCRIPTION
## Summary
- remove jack-server and libjack from imx-image-full to avoid missing jack-utils
- disable JACK integration in PipeWire since the image no longer ships JACK packages

## Testing
- `MACHINE=imx8mp-lpddr4-evk DISTRO=fsl-imx-xwayland source setup-environment build` *(fails: EULA not accepted, but environment configured)*
- `bitbake imx-image-full` *(fails: locale 'en_US.UTF-8' is unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68b45b5b4e2c8327939c9b04f1067b0a