### PR TITLE
Fix SPL legacy image patch formatting

### DIFF
--- a/sources/meta-imx/meta-imx-bsp/recipes-bsp/u-boot/files/0001-imx8mp-enable-spl-legacy-image-support.patch
+++ b/sources/meta-imx/meta-imx-bsp/recipes-bsp/u-boot/files/0001-imx8mp-enable-spl-legacy-image-support.patch
@@ -15,9 +15,10 @@ Signed-off-by: Anonymous <anonymous@example.com>
  configs/imx8mp_evk_defconfig | 1 +
  1 file changed, 1 insertion(+)
 
+diff --git a/configs/imx8mp_evk_defconfig b/configs/imx8mp_evk_defconfig
 --- a/configs/imx8mp_evk_defconfig
 +++ b/configs/imx8mp_evk_defconfig
-@@
+@@ -1,4 +1,5 @@
  CONFIG_SPL_LOAD_FIT=y
 +CONFIG_SPL_LEGACY_IMAGE_SUPPORT=y
  CONFIG_SPL_FIT_GENERATOR="arch/arm/mach-imx/mkimage_fit_atf.sh"


### PR DESCRIPTION
## Summary
- fix malformed patch enabling SPL legacy image support in u-boot config

## Testing
- `bitbake -c patch u-boot-imx` *(fails: Do not use Bitbake as root)*

------
https://chatgpt.com/codex/tasks/task_e_68b4b0cfefe88327b398ea804f6cab3d