### PR TITLE
Fix SPL legacy image support patch for imx8mp U-Boot

### DIFF
--- a/sources/meta-imx/meta-imx-bsp/recipes-bsp/u-boot/files/0001-imx8mp-enable-spl-legacy-image-support.patch
+++ b/sources/meta-imx/meta-imx-bsp/recipes-bsp/u-boot/files/0001-imx8mp-enable-spl-legacy-image-support.patch
@@ -18,9 +18,10 @@ Signed-off-by: Anonymous <anonymous@example.com>
 diff --git a/configs/imx8mp_evk_defconfig b/configs/imx8mp_evk_defconfig
 --- a/configs/imx8mp_evk_defconfig
 +++ b/configs/imx8mp_evk_defconfig
-@@ -1,4 +1,5 @@
+@@ -21,5 +21,6 @@ CONFIG_SYS_LOAD_ADDR=0x40480000
+ CONFIG_FIT=y
+ CONFIG_FIT_EXTERNAL_OFFSET=0x3000
  CONFIG_SPL_LOAD_FIT=y
 +CONFIG_SPL_LEGACY_IMAGE_SUPPORT=y
- CONFIG_SPL_FIT_GENERATOR="arch/arm/mach-imx/mkimage_fit_atf.sh"
- CONFIG_OF_BOARD_FIXUP=y
- CONFIG_OF_BOARD_SETUP=y
+ CONFIG_SYS_BOOTM_LEN=0x2000000
+ CONFIG_DISTRO_DEFAULTS=y


### PR DESCRIPTION
## Summary
- update imx8mp SPL legacy image support patch to match 2024.04 defconfig

## Testing
- `bitbake -c patch u-boot-imx` *(fails: Please make sure locale 'en_US.UTF-8' is available on your system)*

------
https://chatgpt.com/codex/tasks/task_e_68b4b3cd84f88327a3d2762e04083af4