### PR TITLE
Fix U-Boot SPL legacy image support patch for i.MX8MP

### DIFF
--- a/sources/meta-imx/meta-imx-bsp/recipes-bsp/u-boot/files/0001-imx8mp-enable-spl-legacy-image-support.patch
+++ b/sources/meta-imx/meta-imx-bsp/recipes-bsp/u-boot/files/0001-imx8mp-enable-spl-legacy-image-support.patch
@@ -18,10 +18,10 @@ Signed-off-by: Anonymous <anonymous@example.com>
 diff --git a/configs/imx8mp_evk_defconfig b/configs/imx8mp_evk_defconfig
 --- a/configs/imx8mp_evk_defconfig
 +++ b/configs/imx8mp_evk_defconfig
-@@ -21,5 +21,6 @@ CONFIG_SYS_LOAD_ADDR=0x40480000
- CONFIG_FIT=y
+@@ -29,6 +29,7 @@ CONFIG_FIT=y
  CONFIG_FIT_EXTERNAL_OFFSET=0x3000
  CONFIG_SPL_LOAD_FIT=y
 +CONFIG_SPL_LEGACY_IMAGE_SUPPORT=y
- CONFIG_SYS_BOOTM_LEN=0x2000000
- CONFIG_DISTRO_DEFAULTS=y
+ CONFIG_REMAKE_ELF=y
+ CONFIG_OF_BOARD_FIXUP=y
+ CONFIG_OF_BOARD_SETUP=y


### PR DESCRIPTION
## Summary
- adjust SPL legacy image support patch to match current i.MX8MP defconfig

## Testing
- `patch -d "$tmpdir" -p1 --dry-run < sources/meta-imx/meta-imx-bsp/recipes-bsp/u-boot/files/0001-imx8mp-enable-spl-legacy-image-support.patch`
- `bitbake u-boot-imx -c patch` *(fails: Please make sure locale 'en_US.UTF-8' is available on your system)*

------
https://chatgpt.com/codex/tasks/task_e_68b4b5778a58832780db24545eaeeefb