### PR TITLE
u-boot-imx: refresh legacy image support patch

### DIFF
--- a/sources/meta-imx/meta-imx-bsp/recipes-bsp/u-boot/files/0001-imx8mp-enable-spl-legacy-image-support.patch
+++ b/sources/meta-imx/meta-imx-bsp/recipes-bsp/u-boot/files/0001-imx8mp-enable-spl-legacy-image-support.patch
@@ -10,15 +10,19 @@ legacy uImage, preventing U-Boot proper from starting.
 Enable CONFIG_SPL_LEGACY_IMAGE_SUPPORT in the imx8mp_evk_defconfig so
 the SPL can boot legacy images packed in NXP's flash.bin container.
 
+Upstream-Status: Pending
+
 Signed-off-by: Anonymous <anonymous@example.com>
 ---
  configs/imx8mp_evk_defconfig | 1 +
  1 file changed, 1 insertion(+)
 
 diff --git a/configs/imx8mp_evk_defconfig b/configs/imx8mp_evk_defconfig
+index 7112fdf..4954333 100644
 --- a/configs/imx8mp_evk_defconfig
 +++ b/configs/imx8mp_evk_defconfig
-@@ -29,6 +29,7 @@ CONFIG_FIT=y
+@@ -29,6 +29,7 @@ CONFIG_BOOTCOMMAND="run sr_ir_v2_cmd;run distro_bootcmd;run bsp_bootcmd"
+ CONFIG_FIT=y
  CONFIG_FIT_EXTERNAL_OFFSET=0x3000
  CONFIG_SPL_LOAD_FIT=y
 +CONFIG_SPL_LEGACY_IMAGE_SUPPORT=y


### PR DESCRIPTION
## Summary
- refresh imx8mp SPL legacy image support patch to apply cleanly
- add Upstream-Status metadata

## Testing
- `source setup-environment build` *(fails: do not use the BSP as root)*


------
https://chatgpt.com/codex/tasks/task_e_68b4b6fa26508327a1e4eb4224e235a0