### PR TITLE
onnxruntime: use GitHub mirror for Eigen

### DIFF
--- a/sources/meta-imx/meta-imx-ml/recipes-libraries/onnxruntime/onnxruntime/0001-Use-GitHub-Eigen-mirror.patch
+++ b/sources/meta-imx/meta-imx-ml/recipes-libraries/onnxruntime/onnxruntime/0001-Use-GitHub-Eigen-mirror.patch
@@ -1,0 +1,36 @@
+From 1edb7f8f4a8f0c9371d1ca83c6d8681c29b66e2f Mon Sep 17 00:00:00 2001
+From: OpenAI Assistant <assistant@example.com>
+Date: Thu, 10 Oct 2024 00:00:00 +0000
+Subject: [PATCH] Use GitHub Eigen mirror
+
+Switch Eigen dependency from GitLab to the GitHub mirror to avoid
+unstable archive hashes. The new archive is verified with its SHA1
+checksum.
+
+Upstream-Status: Pending
+---
+ cmake/deps.txt | 9 +++------
+ 1 file changed, 3 insertions(+), 6 deletions(-)
+
+diff --git a/cmake/deps.txt b/cmake/deps.txt
+index ba9c2bb73..c8aed070f 100644
+--- a/cmake/deps.txt
++++ b/cmake/deps.txt
+@@ -16,12 +16,9 @@ abseil_cpp;https://github.com/abseil/abseil-cpp/archive/refs/tags/20240116.0.zip
+ cxxopts;https://github.com/jarro2783/cxxopts/archive/3c73d91c0b04e2b59462f0a741be8c07024c1bc0.zip;6c6ca7f8480b26c8d00476e0e24b7184717fe4f0
+ date;https://github.com/HowardHinnant/date/archive/refs/tags/v3.0.1.zip;2dac0c81dc54ebdd8f8d073a75c053b04b56e159
+ dlpack;https://github.com/dmlc/dlpack/archive/refs/tags/v0.6.zip;4d565dd2e5b31321e5549591d78aa7f377173445
+-# This Eigen commit id matches the eigen archive being consumed from https://gitlab.com/libeigen/eigen/-/archive/3.4/eigen-3.4.zip
+-# prior to the 3.4.1 RC changing the bits and invalidating the hash.
+-# it contains changes on top of 3.4.0 which are required to fix build issues.
+-# Until the 3.4.1 release this is the best option we have.
+-# Issue link: https://gitlab.com/libeigen/eigen/-/issues/2744
+-eigen;https://gitlab.com/libeigen/eigen/-/archive/e7248b26a1ed53fa030c5c459f7ea095dfd276ac/eigen-e7248b26a1ed53fa030c5c459f7ea095dfd276ac.zip;be8be39fdbc6e60e94fa7870b280707069b5b81a
++# Moved to github mirror to avoid gitlab issues.
++# Issue link: https://github.com/bazelbuild/bazel-central-registry/issues/4355
++eigen;https://github.com/eigen-mirror/eigen/archive/1d8b82b0740839c0de7f1242a3585e3390ff5f33/eigen-1d8b82b0740839c0de7f1242a3585e3390ff5f33.zip;05b19b49e6fbb91246be711d801160528c135e34
+ flatbuffers;https://github.com/google/flatbuffers/archive/refs/tags/v1.12.0.zip;ba0a75fd12dbef8f6557a74e611b7a3d0c5fe7bf
+ fp16;https://github.com/Maratyszcza/FP16/archive/0a92994d729ff76a58f692d3028ca1b64b145d91.zip;b985f6985a05a1c03ff1bb71190f66d8f98a1494
+ fxdiv;https://github.com/Maratyszcza/FXdiv/archive/63058eff77e11aa15bf531df5dd34395ec3017c8.zip;a5658f4036402dbca7cebee32be57fb8149811e1
+-- 
+2.39.5

--- a/sources/meta-imx/meta-imx-ml/recipes-libraries/onnxruntime/onnxruntime_1.17.1.bb
+++ b/sources/meta-imx/meta-imx-ml/recipes-libraries/onnxruntime/onnxruntime_1.17.1.bb
@@ -10,7 +10,9 @@ DEPENDS = "libpng zlib"
 
 inherit setuptools3
 
-SRC_URI = "${ONNXRUNTIME_SRC};branch=${SRCBRANCH}"
+SRC_URI = "${ONNXRUNTIME_SRC};branch=${SRCBRANCH} \\
+           file://0001-Use-GitHub-Eigen-mirror.patch \\
+          "
 ONNXRUNTIME_SRC ?= "gitsm://github.com/nxp-imx/onnxruntime-imx.git;protocol=https"
 SRCBRANCH = "lf-6.6.36_2.1.0"
 SRCREV = "813b93f64103847a21227725cb5ab04b6ca5b5ed"


### PR DESCRIPTION
## Summary
- switch eigen dependency to GitHub mirror to avoid hash mismatches during fetch

## Testing
- `curl -L https://github.com/eigen-mirror/eigen/archive/1d8b82b0740839c0de7f1242a3585e3390ff5f33/eigen-1d8b82b0740839c0de7f1242a3585e3390ff5f33.zip -o /tmp/eigen.zip`
- `sha1sum /tmp/eigen.zip`
- `MACHINE=imx8mp-lpddr4-evk DISTRO=fsl-imx-xwayland source setup-environment builddir` *(fails: do not use the BSP as root)*
- `bitbake -n onnxruntime` *(fails: Please make sure locale 'en_US.UTF-8' is available)*

------
https://chatgpt.com/codex/tasks/task_e_68b7f4fb212c8327b0f858cd2e8972f1