### PR TITLE
Fix SRC_URI line continuations in onnxruntime recipe

### DIFF
--- a/sources/meta-imx/meta-imx-ml/recipes-libraries/onnxruntime/onnxruntime_1.17.1.bb
+++ b/sources/meta-imx/meta-imx-ml/recipes-libraries/onnxruntime/onnxruntime_1.17.1.bb
@@ -10,8 +10,8 @@ DEPENDS = "libpng zlib"
 
 inherit setuptools3
 
-SRC_URI = "${ONNXRUNTIME_SRC};branch=${SRCBRANCH} \\
-           file://0001-Use-GitHub-Eigen-mirror.patch \\
+SRC_URI = "${ONNXRUNTIME_SRC};branch=${SRCBRANCH} \
+           file://0001-Use-GitHub-Eigen-mirror.patch \
           "
 ONNXRUNTIME_SRC ?= "gitsm://github.com/nxp-imx/onnxruntime-imx.git;protocol=https"
 SRCBRANCH = "lf-6.6.36_2.1.0"


### PR DESCRIPTION
## Summary
- remove stray backslash entries in SRC_URI to avoid malformed URL errors during parsing

## Testing
- `bitbake -p onnxruntime` *(fails: Do not use Bitbake as root)*

------
https://chatgpt.com/codex/tasks/task_e_68b7f91097948327b993de0457576478