### PR TITLE
onnxruntime: ignore interference-size warning

### DIFF
--- a/sources/meta-imx/meta-imx-ml/recipes-libraries/onnxruntime/onnxruntime_1.17.1.bb
+++ b/sources/meta-imx/meta-imx-ml/recipes-libraries/onnxruntime/onnxruntime_1.17.1.bb
@@ -24,6 +24,11 @@ inherit cmake python3native
 OECMAKE_SOURCEPATH = "${S}/cmake"
 OECMAKE_GENERATOR = "Unix Makefiles"
 
+# GCC 13 introduces -Winterference-size, which Eigen triggers when
+# using std::hardware_destructive_interference_size. Treat this
+# warning as non-fatal to allow building with new toolchains.
+CXXFLAGS:append = " -Wno-error=interference-size"
+
 # Notes:
 # Abseil:
 #   - FETCHCONTENT_FULLY_DISCONNECTED=OFF and do_configure:prepend() added to allow


### PR DESCRIPTION
## Summary
- silence -Winterference-size triggered by Eigen in GCC 13 by treating it as non-fatal

## Testing
- `bitbake --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8224e8548832795cf1255353a7744