### PR TITLE
imx-boot: build flash.bin with FIT second loader

### DIFF
--- a/sources/base/recipes-bsp/imx-boot/imx-boot_%.bbappend
+++ b/sources/base/recipes-bsp/imx-boot/imx-boot_%.bbappend
@@ -1,0 +1,19 @@
+# Ensure flash.bin uses FIT second loader at 0x60000 for imx8mpevk
+
+do_compile:append() {
+    if [ "${MACHINE}" = "imx8mpevk" ]; then
+        bbnote "Regenerating u-boot.itb and flash.bin for ${MACHINE}"
+        rm -f ${BOOT_STAGING}/u-boot.itb ${BOOT_STAGING}/flash.bin
+        ${STAGING_BINDIR_NATIVE}/mkimage -E -p 0x5000 -f ${BOOT_STAGING}/u-boot.its ${BOOT_STAGING}/u-boot.itb
+        ${BOOT_STAGING}/mkimage_imx8 -version v2 -fit \
+            -loader ${BOOT_STAGING}/u-boot-spl-ddr.bin 0x920000 \
+            -second_loader ${BOOT_STAGING}/u-boot.itb 0x40200000 0x60000 \
+            -out ${BOOT_STAGING}/flash.bin
+    fi
+}
+
+do_deploy:append() {
+    if [ "${MACHINE}" = "imx8mpevk" ]; then
+        install -m 0644 ${BOOT_STAGING}/flash.bin ${DEPLOYDIR}/imx-boot-${MACHINE}-sd.bin-flash_evk
+    fi
+}


### PR DESCRIPTION
## Summary
- regenerate u-boot.itb and flash.bin during imx-boot compile for imx8mpevk
- deploy flash.bin with FIT second loader at offset 0x60000

## Testing
- `bitbake -n imx-boot` *(fails: Please make sure locale 'en_US.UTF-8' is available on your system)*

------
https://chatgpt.com/codex/tasks/task_e_68b88ccbdf988327ac6c0eeea3a441c6