### PR TITLE
Ensure U-Boot SPL FIT address fragment is applied

### DIFF
--- a/meta-local/recipes-bsp/u-boot/u-boot-imx/u-boot-imx_%.bbappend
+++ b/meta-local/recipes-bsp/u-boot/u-boot-imx/u-boot-imx_%.bbappend
@@ -1,1 +1,4 @@
-UBOOT_CONFIG_FRAGMENTS:append = " ${THISDIR}/u-boot-spl-fitaddr.cfg"
+FILESEXTRAPATHS:prepend := "${THISDIR}:"
+
+# Add FIT load address configuration for SPL
+SRC_URI:append = " file://u-boot-spl-fitaddr.cfg"


### PR DESCRIPTION
## Summary
- ensure U-Boot config fragment to set SPL FIT load address is included via SRC_URI

## Testing
- `bitbake --version`
- `MACHINE=imx8mpevk DISTRO=fsl-imx-wayland . ./setup-environment build` *(fails: Do you accept the EULA you just read?)*

------
https://chatgpt.com/codex/tasks/task_e_68ba077d720883279f06c391f445a42b