### PR TITLE
Add Flutter layer setup script and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,3 +82,15 @@ $ bitbake imx-image-full
 ```
 
  
+## Flutter and Dart support
+A helper script is available to fetch the meta-flutter layer and its dependencies:
+
+```bash
+$ ./scripts/setup-flutter.sh
+$ DISTRO=<distro name> MACHINE=<machine name> source imx-setup-release.sh -b <build dir>
+$ bitbake-layers add-layer ../sources/meta-clang ../sources/meta-flutter
+$ echo 'IMAGE_INSTALL:append = " flutter-engine flutter-embedded-linux"' >> conf/local.conf
+$ bitbake imx-image-full
+```
+
+The `flutter-engine` and `flutter-embedded-linux` packages provide the Flutter engine and Dart runtime, while the `flutter-sdk` recipe supplies the `dart` command-line tools on the host.

--- a/scripts/setup-flutter.sh
+++ b/scripts/setup-flutter.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+LAYER_DIR="$REPO_DIR/sources"
+
+clone_layer() {
+  local repo=$1
+  local dest=$2
+  if [ ! -d "$dest" ]; then
+    git clone "$repo" "$dest"
+  else
+    echo "$dest already exists, skipping clone"
+  fi
+}
+
+clone_layer https://github.com/kraj/meta-clang.git "$LAYER_DIR/meta-clang"
+clone_layer https://github.com/sony/meta-flutter.git "$LAYER_DIR/meta-flutter"
+
+cat <<'EOM'
+meta-flutter and its dependency meta-clang have been cloned into the sources directory.
+After sourcing your build environment run:
+  bitbake-layers add-layer ../sources/meta-clang ../sources/meta-flutter
+and append the following to conf/local.conf to include Dart and Flutter in images:
+  IMAGE_INSTALL:append = " flutter-engine flutter-embedded-linux"
+The flutter-sdk recipe also provides the dart command-line tools on the host.
+EOM


### PR DESCRIPTION
## Summary
- add script to fetch meta-flutter and its dependency meta-clang
- document how to enable Flutter and Dart support in builds

## Testing
- `bash -n scripts/setup-flutter.sh`


------
https://chatgpt.com/codex/tasks/task_e_68bc4f4155908327bf636ac217c4bb73