### PR TITLE
Add checksums and configure Flutter recipes

### DIFF
--- a/meta-local/recipes-devtools/dart/dart-sdk_3.7.0.bb
+++ b/meta-local/recipes-devtools/dart/dart-sdk_3.7.0.bb
@@ -6,6 +6,9 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=29b4ad63b1f1509efea6629404336393"
 SRC_URI = "https://storage.googleapis.com/dart-archive/channels/stable/release/3.7.0/sdk/dartsdk-linux-arm64-release.zip"
 SRC_URI:class-native = "https://storage.googleapis.com/dart-archive/channels/stable/release/3.7.0/sdk/dartsdk-linux-x64-release.zip"
 SRC_URI:class-nativesdk = "https://storage.googleapis.com/dart-archive/channels/stable/release/3.7.0/sdk/dartsdk-linux-x64-release.zip"
+SRC_URI[sha256sum] = "7c849abc0d06a130d26d71490d5f2b4b2fe1ca477b1a9cee6b6d870e6f9d626f"
+SRC_URI[sha256sum]:class-native = "367b5a6f1364a1697dc597775e5cd7333c332363902683a0970158cbb978b80d"
+SRC_URI[sha256sum]:class-nativesdk = "367b5a6f1364a1697dc597775e5cd7333c332363902683a0970158cbb978b80d"
 S = "${WORKDIR}/dart-sdk"
 
 inherit pkgconfig

--- a/meta-local/recipes-devtools/flutter/flutter-sdk_3.13.9.bb
+++ b/meta-local/recipes-devtools/flutter/flutter-sdk_3.13.9.bb
@@ -6,6 +6,9 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=1d84cf16c48e571923f837136633a265"
 SRC_URI = "https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_3.13.9-stable.tar.xz"
 SRC_URI:class-native = "https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_3.13.9-stable.tar.xz"
 SRC_URI:class-nativesdk = "https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_3.13.9-stable.tar.xz"
+SRC_URI[sha256sum] = "b6bc6f93423488c67110e0fe56523cd2260f3a4c379ed015cd1c7fab66362739"
+SRC_URI[sha256sum]:class-native = "b6bc6f93423488c67110e0fe56523cd2260f3a4c379ed015cd1c7fab66362739"
+SRC_URI[sha256sum]:class-nativesdk = "b6bc6f93423488c67110e0fe56523cd2260f3a4c379ed015cd1c7fab66362739"
 S = "${WORKDIR}/flutter"
 
 inherit pkgconfig

--- a/meta-local/recipes-graphics/flutter/flutter-embedded_git.bb
+++ b/meta-local/recipes-graphics/flutter/flutter-embedded_git.bb
@@ -10,7 +10,8 @@ S = "${WORKDIR}/git"
 
 inherit cmake pkgconfig
 
-DEPENDS += "wayland wayland-native"
+DEPENDS += "wayland wayland-native virtual/egl"
+EXTRA_OECMAKE += "-DUSER_PROJECT_PATH=${S}/examples/flutter-wayland-client"
 
 # do_install simply installs demo binary if build executed
 # do_install will not run under -n parse


### PR DESCRIPTION
## Summary
- fix dart-sdk and flutter-sdk recipes by adding sha256 checksums
- set flutter-embedded build to use wayland example and depend on EGL

## Testing
- ⚠️ `source setup-environment build && bitbake -c fetch dart-sdk flutter-sdk flutter-embedded` *(fails: do not use the BSP as root)*

------
https://chatgpt.com/codex/tasks/task_e_68bca4dd247c8327902748f637a780cc