### PR TITLE
Fix Dart SDK checksum override syntax

### DIFF
--- a/meta-local/recipes-devtools/dart/dart-sdk_3.7.0.bb
+++ b/meta-local/recipes-devtools/dart/dart-sdk_3.7.0.bb
@@ -7,8 +7,8 @@ SRC_URI = "https://storage.googleapis.com/dart-archive/channels/stable/release/3
 SRC_URI:class-native = "https://storage.googleapis.com/dart-archive/channels/stable/release/3.7.0/sdk/dartsdk-linux-x64-release.zip"
 SRC_URI:class-nativesdk = "https://storage.googleapis.com/dart-archive/channels/stable/release/3.7.0/sdk/dartsdk-linux-x64-release.zip"
 SRC_URI[sha256sum] = "7c849abc0d06a130d26d71490d5f2b4b2fe1ca477b1a9cee6b6d870e6f9d626f"
-SRC_URI[sha256sum]:class-native = "367b5a6f1364a1697dc597775e5cd7333c332363902683a0970158cbb978b80d"
-SRC_URI[sha256sum]:class-nativesdk = "367b5a6f1364a1697dc597775e5cd7333c332363902683a0970158cbb978b80d"
+SRC_URI[sha256sum:class-native] = "367b5a6f1364a1697dc597775e5cd7333c332363902683a0970158cbb978b80d"
+SRC_URI[sha256sum:class-nativesdk] = "367b5a6f1364a1697dc597775e5cd7333c332363902683a0970158cbb978b80d"
 S = "${WORKDIR}/dart-sdk"
 
 inherit pkgconfig


### PR DESCRIPTION
## Summary
- fix Dart SDK recipe variable flag syntax for class-specific checksums

## Testing
- `bitbake -n dart-sdk` *(fails: Fetcher failure for URL 'https://yoctoproject.org/connectivity.html')*


------
https://chatgpt.com/codex/tasks/task_e_68bd371fc12c8327b25ad1a267bbe050