### PR TITLE
Fix recipe checksum syntax for Dart and Flutter SDKs

### DIFF
--- a/meta-local/recipes-devtools/dart/dart-sdk_3.7.0.bb
+++ b/meta-local/recipes-devtools/dart/dart-sdk_3.7.0.bb
@@ -7,8 +7,8 @@ SRC_URI = "https://storage.googleapis.com/dart-archive/channels/stable/release/3
 SRC_URI:class-native = "https://storage.googleapis.com/dart-archive/channels/stable/release/3.7.0/sdk/dartsdk-linux-x64-release.zip"
 SRC_URI:class-nativesdk = "https://storage.googleapis.com/dart-archive/channels/stable/release/3.7.0/sdk/dartsdk-linux-x64-release.zip"
 SRC_URI[sha256sum] = "7c849abc0d06a130d26d71490d5f2b4b2fe1ca477b1a9cee6b6d870e6f9d626f"
-SRC_URI[sha256sum:class-native] = "367b5a6f1364a1697dc597775e5cd7333c332363902683a0970158cbb978b80d"
-SRC_URI[sha256sum:class-nativesdk] = "367b5a6f1364a1697dc597775e5cd7333c332363902683a0970158cbb978b80d"
+SRC_URI:class-native[sha256sum] = "367b5a6f1364a1697dc597775e5cd7333c332363902683a0970158cbb978b80d"
+SRC_URI:class-nativesdk[sha256sum] = "367b5a6f1364a1697dc597775e5cd7333c332363902683a0970158cbb978b80d"
 S = "${WORKDIR}/dart-sdk"
 
 inherit pkgconfig

--- a/meta-local/recipes-devtools/flutter/flutter-sdk_3.13.9.bb
+++ b/meta-local/recipes-devtools/flutter/flutter-sdk_3.13.9.bb
@@ -7,8 +7,8 @@ SRC_URI = "https://storage.googleapis.com/flutter_infra_release/releases/stable/
 SRC_URI:class-native = "https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_3.13.9-stable.tar.xz"
 SRC_URI:class-nativesdk = "https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_3.13.9-stable.tar.xz"
 SRC_URI[sha256sum] = "b6bc6f93423488c67110e0fe56523cd2260f3a4c379ed015cd1c7fab66362739"
-SRC_URI[sha256sum]:class-native = "b6bc6f93423488c67110e0fe56523cd2260f3a4c379ed015cd1c7fab66362739"
-SRC_URI[sha256sum]:class-nativesdk = "b6bc6f93423488c67110e0fe56523cd2260f3a4c379ed015cd1c7fab66362739"
+SRC_URI:class-native[sha256sum] = "b6bc6f93423488c67110e0fe56523cd2260f3a4c379ed015cd1c7fab66362739"
+SRC_URI:class-nativesdk[sha256sum] = "b6bc6f93423488c67110e0fe56523cd2260f3a4c379ed015cd1c7fab66362739"
 S = "${WORKDIR}/flutter"
 
 inherit pkgconfig


### PR DESCRIPTION
## Summary
- fix per-class sha256 sum syntax in dart-sdk recipe
- fix per-class sha256 sum syntax in flutter-sdk recipe

## Testing
- `bitbake dart-sdk -n` *(fails: No recipes in default available for: /workspace/yocto-nxp-debix/meta-local/recipes-core/images/imx-image-full.bbappend)*

------
https://chatgpt.com/codex/tasks/task_e_68bd8a7cd04c83278704aa89961e536d