### PR TITLE
flutter-embedded: add xkbcommon dependency

### DIFF
--- a/meta-local/recipes-graphics/flutter/flutter-embedded_git.bb
+++ b/meta-local/recipes-graphics/flutter/flutter-embedded_git.bb
@@ -10,7 +10,7 @@ S = "${WORKDIR}/git"
 
 inherit cmake pkgconfig
 
-DEPENDS += "wayland wayland-native virtual/egl"
+DEPENDS += "wayland wayland-native virtual/egl libxkbcommon"
 EXTRA_OECMAKE += "-DUSER_PROJECT_PATH=${S}/examples/flutter-wayland-client"
 
 # do_install simply installs demo binary if build executed


### PR DESCRIPTION
## Summary
- fix flutter-embedded configure failure by adding missing libxkbcommon build dependency

## Testing
- `bitbake flutter-embedded -c cleanall` *(fails: Do not use Bitbake as root)*

------
https://chatgpt.com/codex/tasks/task_e_68bd8e3fae14832794cdb073697b72b7