### PR TITLE
Use Flutter SDK engine and skip dart strip QA

### DIFF
--- a/meta-local/recipes-devtools/dart/dart-sdk_3.7.0.bb
+++ b/meta-local/recipes-devtools/dart/dart-sdk_3.7.0.bb
@@ -27,4 +27,5 @@ do_install() {
 FILES:${PN} += "/opt/${PN}"
 
 RDEPENDS:${PN} += "bash"
+INSANE_SKIP:${PN} += "already-stripped"
 

--- a/meta-local/recipes-graphics/flutter/files/use-flutter-sdk-engine.patch
+++ b/meta-local/recipes-graphics/flutter/files/use-flutter-sdk-engine.patch
@@ -1,0 +1,7 @@
+--- a/cmake/build.cmake
++++ b/cmake/build.cmake
+@@
+-set(FLUTTER_EMBEDDER_LIB "${CMAKE_CURRENT_SOURCE_DIR}/build/libflutter_engine.so")
++if(NOT DEFINED FLUTTER_EMBEDDER_LIB)
++  set(FLUTTER_EMBEDDER_LIB "${CMAKE_CURRENT_SOURCE_DIR}/build/libflutter_engine.so")
++endif()

--- a/meta-local/recipes-graphics/flutter/flutter-embedded_git.bb
+++ b/meta-local/recipes-graphics/flutter/flutter-embedded_git.bb
@@ -4,14 +4,19 @@ LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=d45359c88eb146940e4bede4f08c821a"
 
 SRC_URI = "git://github.com/sony/flutter-embedded-linux.git;branch=master;protocol=https"
+SRC_URI += " file://use-flutter-sdk-engine.patch"
 SRCREV = "1653fa656bf9fe9fa5f84789a59b0c07671a8fc8"
 
 S = "${WORKDIR}/git"
 
 inherit cmake pkgconfig
 
-DEPENDS += "wayland wayland-native virtual/egl libxkbcommon"
+FLUTTER_ENGINE_SUBDIR = "${@'linux-arm64-release' if d.getVar('TARGET_ARCH') == 'aarch64' else 'linux-x64-release'}"
+FLUTTER_ENGINE_LIB_PATH = "${RECIPE_SYSROOT}/opt/flutter-sdk/bin/cache/artifacts/engine/${FLUTTER_ENGINE_SUBDIR}/libflutter_engine.so"
+
+DEPENDS += "wayland wayland-native virtual/egl libxkbcommon flutter-sdk"
 EXTRA_OECMAKE += "-DUSER_PROJECT_PATH=${S}/examples/flutter-wayland-client"
+EXTRA_OECMAKE += " -DFLUTTER_EMBEDDER_LIB=${FLUTTER_ENGINE_LIB_PATH}"
 
 # do_install simply installs demo binary if build executed
 # do_install will not run under -n parse


### PR DESCRIPTION
## Summary
- Allow overriding Flutter engine library and link to engine from Flutter SDK
- Suppress already-stripped QA errors for Dart SDK

## Testing
- ⚠️ `source setup-environment Model_AB_Infinity` (fails: do not use the BSP as root)

------
https://chatgpt.com/codex/tasks/task_e_68bd9067af50832781f3438b303e7db3