### PR TITLE
Fix flutter patch format

### DIFF
--- a/meta-local/recipes-graphics/flutter/files/use-flutter-sdk-engine.patch
+++ b/meta-local/recipes-graphics/flutter/files/use-flutter-sdk-engine.patch
@@ -1,6 +1,7 @@
+diff --git a/cmake/build.cmake b/cmake/build.cmake
 --- a/cmake/build.cmake
 +++ b/cmake/build.cmake
-@@
+@@ -1,1 +1,3 @@
 -set(FLUTTER_EMBEDDER_LIB "${CMAKE_CURRENT_SOURCE_DIR}/build/libflutter_engine.so")
 +if(NOT DEFINED FLUTTER_EMBEDDER_LIB)
 +  set(FLUTTER_EMBEDDER_LIB "${CMAKE_CURRENT_SOURCE_DIR}/build/libflutter_engine.so")


### PR DESCRIPTION
## Summary
- add standard diff headers to use-flutter-sdk-engine.patch

## Testing
- `patch --dry-run -p1 < meta-local/recipes-graphics/flutter/files/use-flutter-sdk-engine.patch`
- `bitbake -c patch flutter-embedded` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd91f12ed88327bc67575fce14bbd2