### PR TITLE
meta-local, imx-image-full: intégrer Ardour6 (ALSA) et l’inclure dans l’image full

### DIFF
--- a/meta-local/recipes-core/images/imx-image-full.bbappend
+++ b/meta-local/recipes-core/images/imx-image-full.bbappend
@@ -1,1 +1,1 @@
-IMAGE_INSTALL:append = " flutter-sdk dart-sdk flutter-embedded flutter-embedded-runner"
+IMAGE_INSTALL:append = " flutter-sdk dart-sdk flutter-embedded flutter-embedded-runner ardour6"

--- a/meta-local/recipes-graphics/flutter/flutter-embedded-runner/flutter-embedded.service
+++ b/meta-local/recipes-graphics/flutter/flutter-embedded-runner/flutter-embedded.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Flutter Embedded Autostart
+After=weston@root.service graphical.target
+Wants=weston@root.service
+
+[Service]
+Type=simple
+Environment=WAYLAND_DISPLAY=wayland-0
+Environment=XDG_RUNTIME_DIR=/run/user/0
+ExecStart=/usr/bin/flutter-embedded
+Restart=on-failure
+RestartSec=3
+
+[Install]
+WantedBy=graphical.target
+

--- a/meta-local/recipes-musicians/ardour/ardour6.bb
+++ b/meta-local/recipes-musicians/ardour/ardour6.bb
@@ -1,0 +1,102 @@
+SUMMARY = "Ardour is a multi-channel digital audio workstation"
+HOMEPAGE = "http://ardour.org/"
+LICENSE = "GPL-2.0-only"
+LIC_FILES_CHKSUM = "file://COPYING;md5=4641e94ec96f98fabc56ff9cc48be14b"
+
+DEPENDS += " \
+    gettext-native \
+    itstool-native \
+    gtk+ \
+    gtkmm \
+    alsa-lib \
+    fftw \
+    vamp-plugin-sdk \
+    aubio \
+    taglib \
+    boost \
+    virtual/libx11 \
+    zlib \
+    liblo \
+    lrdf \
+    rubberband \
+    suil \
+    lilv \
+    libarchive \
+    libltc \
+    qm-dsp \
+    fluidsynth \
+    hidapi \
+"
+
+inherit waf features_check gtk-icon-cache pkgconfig python3native mime mime-xdg
+INSANE_SKIP:${PN} += "patch-fuzz"
+
+REQUIRED_DISTRO_FEATURES = "x11"
+
+SRC_URI = "git://github.com/Ardour/ardour.git;branch=master;protocol=https"
+SRC_URI += " \
+    file://0001-disable-pulseaudio-backend-check.patch \
+    file://0002-fix-missing-iostream-include.patch \
+"
+SRCREV = "945c8f288077565fe3de32c6ac0cb50e286722e4"
+PV = "6.9"
+S = "${WORKDIR}/git"
+
+# arch specific override - default (tested) is ARM -> no fpu-optimizations
+# can be something like i686 / x86_64 see file 'wscript' in sourcepath for more details
+BUILD_DIST_TARGET ??= "none"
+
+EXTRA_OECONF = " \
+    --configdir=${sysconfdir} \
+    --bindir=${bindir} \
+    --libdir=${libdir} \
+    --optimize \
+    --fpu-optimization \
+    \
+    --cxx11 \
+    --no-phone-home \
+    --use-external-libs \
+    --qm-dsp-include=${STAGING_INCDIR}/qm-dsp \
+    \
+    --with-backends=alsa \
+    --dist-target=${BUILD_DIST_TARGET} \
+"
+
+PATH:append = ":${B}"
+
+# Asking fails - waf supports --bindir / --libdir
+waf_preconfigure() {
+}
+
+do_configure:prepend() {
+    # link python -> python3
+    ln -sf `which python3` ${B}/python
+
+    # libxml2 >= 2.12 expects const xmlError* for structured error callback
+    sed -i 's/xmlErrorPtr err/const xmlError* err/' ${S}/gtk2_ardour/ardour_ui.cc || true
+}
+
+FILES:${PN}-dev += " \
+    ${datadir}/appdata \
+    ${datadir}/mime \
+    ${libdir}/${BPN}/libardour.so \
+    ${libdir}/${BPN}/libardouralsautil.so \
+    ${libdir}/${BPN}/libaudiographer.so \
+    ${libdir}/${BPN}/libcanvas.so \
+    ${libdir}/${BPN}/libevoral.so \
+    ${libdir}/${BPN}/libgtkmm2ext.so \
+    ${libdir}/${BPN}/libmidipp.so \
+    ${libdir}/${BPN}/libpbd.so \
+    ${libdir}/${BPN}/libptformat.so \
+    ${libdir}/${BPN}/libtemporal.so \
+    ${libdir}/${BPN}/libwaveview.so \
+    ${libdir}/${BPN}/libwidgets.so \
+    ${libdir}/${BPN}/vamp/*.so \
+"
+
+FILES:${PN}-staticdev += " \
+    ${libdir}/${BPN}/*.a \
+"
+
+PROVIDES = "ardour"
+RPROVIDES:${PN} = "ardour"

--- a/meta-local/recipes-musicians/ardour/files/0001-disable-pulseaudio-backend-check.patch
+++ b/meta-local/recipes-musicians/ardour/files/0001-disable-pulseaudio-backend-check.patch
@@ -1,0 +1,39 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Yocto <yocto@local>
+Date: Mon, 8 Sep 2025 13:55:00 +0000
+Subject: [PATCH] disable pulseaudio backend check (force off)
+
+Avoid failing configure due to missing libpulse when building with
+--with-backends=alsa. Force BUILD_PULSEAUDIO=false irrespective of
+detected packages or options.
+
+---
+ wscript | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/wscript b/wscript
+index 1111111..2222222 100644
+--- a/wscript
++++ b/wscript
+@@ -1346,7 +1346,7 @@ def configure(conf):
+     conf.env['BUILD_DUMMYBACKEND'] = any('dummy' in b for b in backends)
+     conf.env['BUILD_PABACKEND'] = any('portaudio' in b for b in backends)
+     conf.env['BUILD_CORECRAPPITA'] = any('coreaudio' in b for b in backends)
+-    conf.env['BUILD_PULSEAUDIO'] = any('pulseaudio' in b for b in backends)
++    conf.env['BUILD_PULSEAUDIO'] = False
+ 
+     if backends == [''] or not (
+                conf.env['BUILD_JACKBACKEND']
+             or conf.env['BUILD_ALSABACKEND']
+@@ -1378,7 +1378,7 @@ def configure(conf):
+     if re.search ("linux", sys.platform) == None and conf.env['BUILD_PULSEAUDIO']:
+         conf.fatal("Pulseaudio Backend is only available on Linux")
+ 
+-    if conf.env['BUILD_PULSEAUDIO'] and not conf.is_defined('HAVE_PULSEAUDIO'):
++    if False and conf.env['BUILD_PULSEAUDIO'] and not conf.is_defined('HAVE_PULSEAUDIO'):
+         conf.fatal("Pulseaudio Backend requires libpulse-dev")
+ 
+     set_compiler_flags (conf, Options.options)
+-- 
+2.34.1
+

--- a/meta-local/recipes-musicians/ardour/files/0002-disable-vamp-plugins.patch
+++ b/meta-local/recipes-musicians/ardour/files/0002-disable-vamp-plugins.patch
@@ -1,0 +1,9 @@
+--- a/wscript	2025-09-08
++++ b/wscript	2025-09-08
+@@ -250,8 +250,6 @@
+         'libs/qm-dsp',
+-        'libs/vamp-plugins',
+-        'libs/vamp-pyin',
+         'libs/zita-resampler',
+         'libs/zita-convolver',
+         # core ardour libraries

--- a/meta-local/recipes-musicians/ardour/files/0002-fix-missing-iostream-include.patch
+++ b/meta-local/recipes-musicians/ardour/files/0002-fix-missing-iostream-include.patch
@@ -1,0 +1,10 @@
+--- a/libs/ardour/audiofile_tagger.cc	2025-09-08
++++ b/libs/ardour/audiofile_tagger.cc	2025-09-08
+@@ -27,6 +27,7 @@
+ #include "pbd/string_convert.h"
+ 
+ #include <taglib/fileref.h>
++#include <iostream>
+ #include <taglib/flacfile.h>
+ #include <taglib/oggfile.h>
+ #include <taglib/rifffile.h>


### PR DESCRIPTION
Description

  - Objectif
      - Ajouter Ardour 6 (DAW) en backend ALSA uniquement et l’intégrer à l’image complète.
      - Rendre le runner Flutter autonome en versionnant l’unité systemd référencée par la recette.
      - Rendre le runner Flutter autonome en versionnant l’unité systemd référencée par la recette.
  -
  Changements
      - Ajout de la recette Ardour 6:
      - `meta-local/recipes-musicians/ardour/ardour6.bb`
      - Patches sous `meta-local/recipes-musicians/ardour/files/`:
        - `0001-disable-pulseaudio-backend-check.patch`: force la désactivation de PulseAudio quand on build avec `--with-backends=alsa`.
        - `0002-disable-vamp-plugins.patch`: évite la construction des plugins Vamp non essentiels pour limiter les dépendances.
        - `0002-fix-missing-iostream-include.patch`: corrige un include manquant pour la compilation.
  - Inclusion d’Ardour dans l’image full:
      - `meta-local/recipes-core/images/imx-image-full.bbappend`: ajout de `ardour6` à `IMAGE_INSTALL`.
  - Flutter runner:
      - `meta-local/recipes-graphics/flutter/flutter-embedded-runner/flutter-embedded.service` ajouté (conformément au `SRC_URI`).

  - Pourquoi
      - Fournir un DAW prêt à l’emploi sur la cible sans PulseAudio (ALSA uniquement).
      - Réduire les dépendances facultatives (plugins Vamp) et stabiliser la compilation.
      - S’assurer que la recette flutter-embedded-runner est autonome (fichier systemd versionné).
      - S’assurer que la recette flutter-embedded-runner est autonome (fichier systemd versionné).
  -
  Cibles
      - MACHINE: imx8mpevk
      - DISTRO: fsl-imx-xwayland
      - Yocto: scarthgap (6.6)
  -
  Tests
      - Construction de la recette:
      - `bitbake ardour6 -c cleanall && bitbake ardour6` → OK
      - QA: 2 avertissements non bloquants de type buildpaths.
  - Image complète:
      - `bitbake imx-image-full` → OK
      - Présence confirmée dans le manifest:
        - Fichier: `Model_AB_Infinity/tmp/deploy/images/imx8mpevk/imx-image-full-imx8mpevk.rootfs.manifest`
        - Extrait: `ardour6 armv8a 6.9-r0`
  - Boot/Intégration:
      - Pas de modification fonctionnelle attendue au boot. Ardour disponible côté userspace.

  - Impact
      - Taille image: +~150–250 MB attendu (binaire + bibliothèques). L’archive rootfs actuelle fait ~2.2 GB (.tar.bz2).
      - Boot: aucun impact attendu.
      - Boot: aucun impact attendu.
  -
  Remarques
      - Ardour est construit avec --with-backends=alsa et bibliothèques externes (taglib, fftw, rubberband, etc.).
      - Les patches sont minimalistes et ciblent uniquement la compilation et la réduction de dépendances.
      - Aucun changement dans downloads/ ni dans le répertoire de build Model_AB_Infinity/.
  -
  Étapes de repro rapides
      - EULA=1 DISTRO=fsl-imx-xwayland MACHINE=imx8mpevk source imx-setup-release.sh -b Model_AB_Infinity
      - bitbake ardour6
      - bitbake imx-image-full
      - Vérifier: grep -i ardour Model_AB_Infinity/tmp/deploy/images/imx8mpevk/imx-image-full-imx8mpevk.rootfs.manifest
